### PR TITLE
[BW-57][BW-56]Fix: Team entity에 strategy 추가, User entity id -> userId 변경

### DIFF
--- a/src/main/java/com/binary/webide_be/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/binary/webide_be/chat/dto/ChatMessageResponseDto.java
@@ -31,7 +31,7 @@ public class ChatMessageResponseDto {
     public static ChatMessageResponseDto from(ChatMessage chatMessage) {
         return ChatMessageResponseDto.builder()
                 .chatMessageId(chatMessage.getChatMessageId())
-                .userId(chatMessage.getSender().getId())
+                .userId(chatMessage.getSender().getUserId())
                 .userNickName(chatMessage.getSender().getNickName())
                 .userProfileImg(chatMessage.getSender().getProfileImg())
                 .chatMessage(chatMessage.getChatMessage())

--- a/src/main/java/com/binary/webide_be/chat/service/ChatService.java
+++ b/src/main/java/com/binary/webide_be/chat/service/ChatService.java
@@ -36,7 +36,7 @@ public class ChatService {
         List<ChatMessageResponseDto> chatHistory = messages.stream().map(message -> {
             return ChatMessageResponseDto.builder()
                     .chatMessageId(message.getChatMessageId())
-                    .userId(message.getSender().getId())
+                    .userId(message.getSender().getUserId())
                     .userNickName(message.getSender().getNickName())
                     .userProfileImg(message.getSender().getProfileImg())
                     .chatMessage(message.getChatMessage())

--- a/src/main/java/com/binary/webide_be/project/dto/CreatePorjectResponseDto.java
+++ b/src/main/java/com/binary/webide_be/project/dto/CreatePorjectResponseDto.java
@@ -32,7 +32,7 @@ public class CreatePorjectResponseDto {
         this.projectDesc = project.getProjectDesc();
         this.teamId = team.getTeamId();
         this.teamName = team.getTeamName();
-        this.userId = user.getId();
+        this.userId = user.getUserId();
         this.nickName = user.getNickName();
         this.email = user.getEmail();
         this.profileImage = user.getProfileImg();

--- a/src/main/java/com/binary/webide_be/team/entity/Team.java
+++ b/src/main/java/com/binary/webide_be/team/entity/Team.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Team {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long teamId;
 
     @Column(nullable = false)

--- a/src/main/java/com/binary/webide_be/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/binary/webide_be/user/dto/LoginResponseDto.java
@@ -11,7 +11,7 @@ public class LoginResponseDto {
     private String profileImg;
 
     public LoginResponseDto(User user) {
-        this.userId = user.getId();
+        this.userId = user.getUserId();
         this.email = user.getEmail();
         this.nickName = user.getNickName();
         this.profileImg = user.getProfileImg();

--- a/src/main/java/com/binary/webide_be/user/entity/User.java
+++ b/src/main/java/com/binary/webide_be/user/entity/User.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class User {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long userId;
 
     //TODO: 2024-03-14 추후 email unique=true 해 줄 예정입니다. (편의를 위하여 아직 적용하지 않았습니다.)
     @Column(nullable = false)


### PR DESCRIPTION
[BW-57]
- Team entity에 @GeneratedValue(strategy = GenerationType.IDENTITY) 추가

[BW-56]
- 다른 도메인 entity 들과 convention을 맞추기 위해 User entity에 id -> userId로 변경
    - 변경 후 getId() 사용 중인 dto, service를 찾아 getUserId()로 변경

[BW-57]: https://webide-binary.atlassian.net/browse/BW-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BW-56]: https://webide-binary.atlassian.net/browse/BW-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ