### PR TITLE
[BW-66]Fix: h2 bean을 찾지 못한다는 오류 해결, security 설정파일에서 h2 관련 주석 처리

### DIFF
--- a/src/main/java/com/binary/webide_be/config/WebSecurityConfig.java
+++ b/src/main/java/com/binary/webide_be/config/WebSecurityConfig.java
@@ -40,7 +40,7 @@ public class WebSecurityConfig implements WebMvcConfigurer {
     public WebSecurityCustomizer webSecurityCustomizer() {
 
         return (web) -> web.ignoring()
-                .requestMatchers(PathRequest.toH2Console())
+//                .requestMatchers(PathRequest.toH2Console())
 //                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**")
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }


### PR DESCRIPTION
[BW-66] H2 데이터베이스 관련 설정이 주석 처리되어 있지만, 여전히 Spring Boot 애플리케이션에서 해당 빈을 찾고 있어서 오류가 발생
- WebSecurityConfig 파일에  H2 콘솔에 대한 요청을 무시하도록 설정했던 .requestMatchers(PathRequest.toH2Console()) 발견하여 주석 처리

[BW-66]: https://webide-binary.atlassian.net/browse/BW-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ