### PR TITLE
[BW-77][BW-78] Feature/user 회원 정보 수정 api 구현 및 Type definition error 발생하여 해결

### DIFF
--- a/src/main/java/com/binary/webide_be/exception/message/ErrorMsg.java
+++ b/src/main/java/com/binary/webide_be/exception/message/ErrorMsg.java
@@ -15,6 +15,7 @@ public enum  ErrorMsg {
     PASSWORD_INCORRECT_MISMATCH(BAD_REQUEST, "입력하신 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
+    UNAUTHORIZED_MEMBER(UNAUTHORIZED, "인증된 사용자가 아닙니다."),
     NOT_LOGGED_ID(UNAUTHORIZED, "로그인이 되어있지 않습니다."),
 
     /* 403 FORBIDDEN : 권한 없음 */

--- a/src/main/java/com/binary/webide_be/exception/message/SuccessMsg.java
+++ b/src/main/java/com/binary/webide_be/exception/message/SuccessMsg.java
@@ -10,6 +10,7 @@ public enum SuccessMsg {
 
     SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입 완료"),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인 완료"),
+    USER_INFO_UPDATE_SUCCESS(HttpStatus.OK, "회원 정보 수정 완료"),
     EMAIL_CHECK_SUCCESS(HttpStatus.OK,"사용 가능한 이메일입니다."),
     CHAT_HISTORY_SUCCESS(HttpStatus.OK,"채팅 기록 조회 완료"),
     CREATE_TEAM_SUCCESS(HttpStatus.CREATED, "팀 생성 완료"),

--- a/src/main/java/com/binary/webide_be/user/controller/UserController.java
+++ b/src/main/java/com/binary/webide_be/user/controller/UserController.java
@@ -1,17 +1,25 @@
 package com.binary.webide_be.user.controller;
 
+import com.binary.webide_be.user.dto.UpdateUserInfoRequestDto;
+import com.binary.webide_be.security.UserDetailsImpl;
 import com.binary.webide_be.user.dto.CustomEmail;
 import com.binary.webide_be.user.dto.LoginRequestDto;
 import com.binary.webide_be.user.dto.SignupRequestDto;
 import com.binary.webide_be.user.service.UserService;
 import com.binary.webide_be.util.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Validated
 @RestController
@@ -40,5 +48,14 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<ResponseDto<?>> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response){
         return ResponseEntity.ok(userService.login(loginRequestDto, response));
+    }
+
+    @Operation(summary = "회원 정보 수정", description = "[회원 정보 수정] api")
+    @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ResponseDto<?>> updateUserInfo(@RequestPart(value = "updateUserInfoRequestDto") UpdateUserInfoRequestDto updateUserInfoRequestDto,
+                                                         @RequestPart(value = "profileImage",required = false) MultipartFile profileImage,
+                                                         @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) throws IOException {
+        return ResponseEntity.ok(userService.updateUserInfo(updateUserInfoRequestDto, profileImage, userDetails));
     }
 }

--- a/src/main/java/com/binary/webide_be/user/dto/UpdateUserInfoRequestDto.java
+++ b/src/main/java/com/binary/webide_be/user/dto/UpdateUserInfoRequestDto.java
@@ -1,0 +1,9 @@
+package com.binary.webide_be.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserInfoRequestDto {
+    private String nickName;
+    private Boolean deleteProfile;
+}

--- a/src/main/java/com/binary/webide_be/user/dto/UpdateUserInfoResponseDto.java
+++ b/src/main/java/com/binary/webide_be/user/dto/UpdateUserInfoResponseDto.java
@@ -1,7 +1,9 @@
 package com.binary.webide_be.user.dto;
 
 import com.binary.webide_be.user.entity.User;
+import lombok.Getter;
 
+@Getter
 public class UpdateUserInfoResponseDto {
     private String email;
     private String nickName;

--- a/src/main/java/com/binary/webide_be/user/dto/UpdateUserInfoResponseDto.java
+++ b/src/main/java/com/binary/webide_be/user/dto/UpdateUserInfoResponseDto.java
@@ -1,0 +1,15 @@
+package com.binary.webide_be.user.dto;
+
+import com.binary.webide_be.user.entity.User;
+
+public class UpdateUserInfoResponseDto {
+    private String email;
+    private String nickName;
+    private String profileImg;
+
+    public UpdateUserInfoResponseDto(User user, String profileImg) {
+        this.email = user.getEmail();
+        this.nickName = user.getNickName();
+        this.profileImg = profileImg;
+    }
+}

--- a/src/main/java/com/binary/webide_be/user/entity/User.java
+++ b/src/main/java/com/binary/webide_be/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.binary.webide_be.user.entity;
 
+import com.binary.webide_be.user.dto.UpdateUserInfoRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,5 +38,10 @@ public class User {
         this.nickName = nickName;
         this.password = password;
         this.userRole = UserRoleEnum.USER;
+    }
+
+    public void update(String nickName, String profileImageUrl) {
+        this.nickName = nickName;
+        this.profileImg = profileImageUrl;
     }
 }

--- a/src/main/java/com/binary/webide_be/user/service/UserService.java
+++ b/src/main/java/com/binary/webide_be/user/service/UserService.java
@@ -1,14 +1,13 @@
 package com.binary.webide_be.user.service;
 
 import com.binary.webide_be.exception.CustomException;
-import com.binary.webide_be.exception.message.SuccessMsg;
 import com.binary.webide_be.jwt.JwtUtil;
-import com.binary.webide_be.user.dto.LoginRequestDto;
-import com.binary.webide_be.user.dto.LoginResponseDto;
-import com.binary.webide_be.user.dto.SignupRequestDto;
+import com.binary.webide_be.user.dto.*;
+import com.binary.webide_be.security.UserDetailsImpl;
 import com.binary.webide_be.user.entity.User;
 import com.binary.webide_be.user.entity.UserRoleEnum;
 import com.binary.webide_be.user.repository.UserRepository;
+import com.binary.webide_be.util.S3Service;
 import com.binary.webide_be.util.dto.ResponseDto;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -17,7 +16,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.Optional;
 
 import static com.binary.webide_be.exception.message.ErrorMsg.*;
@@ -30,6 +31,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final S3Service s3Service;
 
     //회원가입
     @Transactional
@@ -89,6 +91,36 @@ public class UserService {
                 .statusCode(LOGIN_SUCCESS.getHttpStatus().value())
                 .message(LOGIN_SUCCESS.getDetail())
                 .data(new LoginResponseDto(user))
+                .build();
+    }
+
+    @Transactional
+    public ResponseDto<?> updateUserInfo(UpdateUserInfoRequestDto updateUserInfoRequestDto, MultipartFile profileImage, UserDetailsImpl userDetails) throws IOException {
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow(
+                () -> new CustomException(UNAUTHORIZED_MEMBER)
+        );
+
+        String profileImageUrl = null;
+        String nickName = updateUserInfoRequestDto.getNickName();
+        String email = user.getEmail();
+        if (profileImage != null && !profileImage.isEmpty()) {
+            profileImageUrl = s3Service.uploadFile(profileImage, "image");
+        } else if ((profileImage == null || profileImage.isEmpty()) && (updateUserInfoRequestDto.getDeleteProfile() != null && updateUserInfoRequestDto.getDeleteProfile() == true)) {
+            profileImageUrl = null;
+        } else if (profileImage == null || profileImage.isEmpty()) {
+            profileImageUrl = user.getProfileImg();
+        }
+
+        if (nickName.equals("") || nickName == null) {
+            nickName = user.getNickName();
+        }
+
+        user.update(nickName, profileImageUrl);
+        userRepository.save(user);
+        return ResponseDto.builder()
+                .statusCode(USER_INFO_UPDATE_SUCCESS.getHttpStatus().value())
+                .message(USER_INFO_UPDATE_SUCCESS.getDetail())
+                .data(new UpdateUserInfoResponseDto(user, profileImageUrl))
                 .build();
     }
 }

--- a/src/main/java/com/binary/webide_be/user/service/UserService.java
+++ b/src/main/java/com/binary/webide_be/user/service/UserService.java
@@ -111,7 +111,7 @@ public class UserService {
             profileImageUrl = user.getProfileImg();
         }
 
-        if (nickName.equals("") || nickName == null) {
+        if (nickName == null || nickName.equals("")) { // nickName이 null이면 기존 닉네임으로 설정
             nickName = user.getNickName();
         }
 
@@ -120,7 +120,8 @@ public class UserService {
         return ResponseDto.builder()
                 .statusCode(USER_INFO_UPDATE_SUCCESS.getHttpStatus().value())
                 .message(USER_INFO_UPDATE_SUCCESS.getDetail())
-                .data(new UpdateUserInfoResponseDto(user, profileImageUrl))
+                .data(new UpdateUserInfoResponseDto(user, profileImageUrl)) // user 객체 대신 필요한 필드들을 직접 전달
                 .build();
     }
+
 }

--- a/src/main/java/com/binary/webide_be/util/S3Service.java
+++ b/src/main/java/com/binary/webide_be/util/S3Service.java
@@ -25,10 +25,14 @@ public class S3Service {
 
     @Transactional
     public String uploadFile(MultipartFile multipartFile, String dirName) throws IOException {
-        File uploadFile = convert(multipartFile)  // 파일 변환할 수 없으면 에러
-                .orElseThrow (() -> new IllegalArgumentException("error: MultipartFile -> File convert fail"));
+        Optional<File> convertedFileOptional = convert(multipartFile);
+        if (!convertedFileOptional.isPresent()) {
+            throw new IllegalArgumentException("error: MultipartFile -> File convert fail");
+        }
+        File uploadFile = convertedFileOptional.get();
         return upload(uploadFile, dirName);
     }
+
 
     public String upload(File uploadFile, String filePath) {
         String fileName = filePath + "/" + UUID.randomUUID() + uploadFile.getName();   // S3에 저장된 파일 이름


### PR DESCRIPTION
[BW-77] 회원 정보 수정 api 구현
- 회원의 nickName과 profileImg를 받아 수정하는 api를 구현

[BW-78] Type definition error 발생하여 해결
-  postman으로 회원 정보 수정 api 테스트 시에 data 출력 안됨과 동시에 message가 "Type definition error: [simple type, class com.binary.webide_be.user.dto.UpdateUserInfoResponseDto]" 라는 값으로 출력되는 것을 발견
- UpdateUserInfoResponseDto에 @Getter 를 누락하여 발생한 문제로 @Getter를 추가하여 오류 해결

[BW-77]: https://webide-binary.atlassian.net/browse/BW-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BW-78]: https://webide-binary.atlassian.net/browse/BW-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ