### PR TITLE
[BW-109]Fix: WebSocket + STOMP 수정

### DIFF
--- a/src/main/java/com/binary/webide_be/chat/controller/ChatController.java
+++ b/src/main/java/com/binary/webide_be/chat/controller/ChatController.java
@@ -4,43 +4,29 @@ import com.binary.webide_be.chat.dto.ChatMessageRequestDto;
 import com.binary.webide_be.chat.dto.ChatMessageResponseDto;
 import com.binary.webide_be.chat.service.ChatService;
 import com.binary.webide_be.security.UserDetailsImpl;
-import com.binary.webide_be.util.dto.ResponseDto;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.stereotype.Controller;
 
-@RestController
+@Controller
 @RequiredArgsConstructor
-@RequestMapping("/api/chat")
 public class ChatController {
     private final SimpMessagingTemplate template; //특정 Broker 로 메세지를 전달
     private final ChatService chatService;
 
-    @Operation(summary = "채팅방 - 채팅 내역 조회", description = "[채팅방] api")
-    @GetMapping("/{chatRoomId}")
-    public ResponseEntity<ResponseDto<?>> messageList(
-            @PathVariable Long chatRoomId,
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.ok(chatService.messageList(chatRoomId, userDetails));
-    }
-
-    // WebSocketConfig에서 설정한 applicationDestinationPrefixes 와 @MessageMapping 경로가 병합
-    // /pub/{chatRoomId}/message
-    // /sub/{chatRoomId}/message/topic
-    @MessageMapping("/{chatRoomId}/message")
-    @SendTo("/{chatRoomId}/message/topic")
-    public ChatMessageResponseDto message(
+    @MessageMapping("/{chatRoomId}")
+//    @SendTo("/room/{chatRoomId}")
+    public void message(
             @DestinationVariable Long chatRoomId,
             ChatMessageRequestDto chatMessageRequestDto,
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return chatService.createChatMessage(chatRoomId, chatMessageRequestDto, userDetails);
-     }
+        ChatMessageResponseDto responseDto = chatService.createChatMessage(chatRoomId, chatMessageRequestDto, userDetails);
+        template.convertAndSend("/sub/room/" + chatRoomId, responseDto);
+//        return responseDto;
+    }
 
 }

--- a/src/main/java/com/binary/webide_be/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/binary/webide_be/chat/controller/ChatRoomController.java
@@ -1,0 +1,26 @@
+package com.binary.webide_be.chat.controller;
+
+import com.binary.webide_be.chat.service.ChatService;
+import com.binary.webide_be.security.UserDetailsImpl;
+import com.binary.webide_be.util.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatRoomController {
+    private final ChatService chatService;
+
+    @Operation(summary = "채팅방 - 채팅 내역 조회", description = "[채팅방] api")
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ResponseDto<?>> messageList(
+            @PathVariable Long chatRoomId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(chatService.messageList(chatRoomId, userDetails));
+    }
+}

--- a/src/main/java/com/binary/webide_be/chat/entity/ChatMessage.java
+++ b/src/main/java/com/binary/webide_be/chat/entity/ChatMessage.java
@@ -31,7 +31,7 @@ public class ChatMessage extends TimeStamped {
     private ChatRoom chatRoomId;
 
     public ChatMessage(User user, ChatRoom chatRoom, ChatMessageRequestDto chatMessageRequestDto) {
-        this.sender = sender;
+        this.sender = user;
         this.chatRoomId = chatRoom;
         this.chatMessage = chatMessageRequestDto.getChatMessage();
     }

--- a/src/main/java/com/binary/webide_be/chat/service/ChatService.java
+++ b/src/main/java/com/binary/webide_be/chat/service/ChatService.java
@@ -11,6 +11,7 @@ import com.binary.webide_be.security.UserDetailsImpl;
 import com.binary.webide_be.user.entity.User;
 import com.binary.webide_be.user.repository.UserRepository;
 import com.binary.webide_be.util.dto.ResponseDto;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -47,8 +48,9 @@ public class ChatService {
                 .build();
     }
 
+    @Transactional
     public ChatMessageResponseDto createChatMessage(Long chatRoomId, ChatMessageRequestDto chatMessageRequestDto, UserDetailsImpl userDetails) {
-        User user = userRepository.findByEmail(userDetails.getUsername())
+        User user = userRepository.findById(chatMessageRequestDto.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)

--- a/src/main/java/com/binary/webide_be/config/WebSocketConfig.java
+++ b/src/main/java/com/binary/webide_be/config/WebSocketConfig.java
@@ -14,12 +14,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*");
+                .setAllowedOrigins("*");
     }
     
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setUserDestinationPrefix("/pub");
+        registry.setApplicationDestinationPrefixes("/pub");
         registry.enableSimpleBroker("/sub");
     }
 }


### PR DESCRIPTION
[BW-109]Fix: WebSocket + STOMP 수정

**컨트롤러 분리**
단일 컨트롤러일때 BaseMapping이 되어 있어 WebSocket + STOMP의 pub/sub가 동작을 안한것으로 추정

**에러가 났는데 DB에 변경사항이 저장**
@Transactional을 사용하여 일관성을 지키게 하였음

**WebSocketConfig변경**
configureMessageBroker에 공급자를 설정인 registry.setApplicationDestinationPrefixes("/pub");를 해주었어야하는데
registry.setUserDestinationPrefix("/pub");이렇게 설정을해서 메시지매핑에 오류가 있어 수정하였음

[BW-109]: https://webide-binary.atlassian.net/browse/BW-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ